### PR TITLE
Support for Vivaldi Browser

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ When you save a file it tells the active tab in each of your selected browsers t
 ## Supported browsers
 
 - Chrome
+- Vivaldi
 - Safari
 
 ## Supported platforms

--- a/Readme.md
+++ b/Readme.md
@@ -11,8 +11,8 @@ When you save a file it tells the active tab in each of your selected browsers t
 ## Supported browsers
 
 - Chrome
-- Vivaldi
 - Safari
+- Vivaldi
 
 ## Supported platforms
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser-refresh-on-save",
   "main": "plugin.coffee",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "reloads assets in the browser as soon as you save them",
   "repository": "https://github.com/jkroso/atom-browser-refresh-on-save.git",
   "license": "MIT",

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -32,6 +32,9 @@ plugin = {
     chrome:
       type: 'boolean'
       default: true
+    vivaldi:
+      type: 'boolean'
+      default: true
     safari:
       type: 'boolean'
       default: true
@@ -78,6 +81,7 @@ tell application "Safari" to do JavaScript "{js}" in document 1
 commands = {
   darwin: {
     chrome: MacChromeCmd,
+    vivaldi: MacChromeCmd.replace(/Google Chrome/g, "Vivaldi"),
     safari: MacSafariCmd
   }
 }
@@ -95,6 +99,8 @@ refresh.darwin = (cmd, js) ->
 refreshAll = (js) ->
   if atom.config.get('browser-refresh-on-save.chrome')
     refresh('chrome', js)
+  if atom.config.get('browser-refresh-on-save.vivaldi')
+    refresh('vivaldi', js)
   if atom.config.get('browser-refresh-on-save.safari')
     refresh('safari', js)
 

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -31,12 +31,15 @@ plugin = {
   config:
     chrome:
       type: 'boolean'
-      default: true
-    vivaldi:
-      type: 'boolean'
+      order: 1
       default: true
     safari:
       type: 'boolean'
+      order: 2
+      default: true
+    vivaldi:
+      type: 'boolean'
+      order: 3
       default: true
     scripts:
       type: 'object'


### PR DESCRIPTION
This adds support for Vivaldi Browser which is based on Chromium (or at least on some parts of it), when called it replaces "Google Chrome" string to "Vivaldi" within the applescript that is being used to reload the Chrome tab.

This closes the request I opened:
#6
